### PR TITLE
bugFix/loop-termination-beat-timing

### DIFF
--- a/classes/LightLoop.py
+++ b/classes/LightLoop.py
@@ -1,5 +1,5 @@
 """This module handles the lighting loop thread. """
-
+import time
 from multiprocessing import Process
 from typing import Callable
 from classes.LedColor import LedColor
@@ -46,3 +46,5 @@ class LightLoop:
         """Terminates anything currently running so other lighting processes can be run"""
         if self.process:
             self.process.terminate()
+            # A pause is needed otherwise the next process won't start correctly
+            time.sleep(0.5)

--- a/classes/SpotifyAudioAnalysis.py
+++ b/classes/SpotifyAudioAnalysis.py
@@ -103,6 +103,9 @@ class SpotifyAudioAnalysis:
             else progress_seconds
         )
 
+        if track_time_seconds > self.track_duration:
+            return None
+
         active = {
             "bar": self._binary_search_active(self.bars, track_time_seconds),
             "beat": self._binary_search_active(self.beats, track_time_seconds),

--- a/server.py
+++ b/server.py
@@ -1,4 +1,5 @@
 from typing import List
+import time
 
 from flask import Flask, request
 from flask import Response as FlaskResponse
@@ -196,7 +197,9 @@ def spotify_visualize_dual_beat():
     lag_time_ms = data.get("lag_time_ms")
 
     audio_analysis = SpotifyAudioAnalysis(
-        track_progress=track_progress, lag_time_ms=lag_time_ms, **track_data
+        track_progress=track_progress,
+        lag_time_ms=lag_time_ms,
+        **track_data,
     )
 
     light_loop.terminate_running_process()


### PR DESCRIPTION
 - Fixed bug with secondary thread halting when updating the pixel array in dynamic display after a few songs
 - Added termination and refreshes to threads
 - Shortened length of beats to make sure loop is free to start on next beat